### PR TITLE
fix issue with Annotation reader intead use Attribute loader

### DIFF
--- a/Annotations/ExcludeDoctrineLogging.php
+++ b/Annotations/ExcludeDoctrineLogging.php
@@ -1,13 +1,13 @@
 <?php
 namespace NTI\LogBundle\Annotations;
 
-use Doctrine\Common\Annotations\Annotation;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 
 /**
  * @Annotation
  * @Target("CLASS")
  */
-final class ExcludeDoctrineLogging extends Annotation
+final class ExcludeDoctrineLogging extends AnnotationLoader
 {
 
 }

--- a/EventListener/DoctrineEventSubscriber.php
+++ b/EventListener/DoctrineEventSubscriber.php
@@ -4,7 +4,7 @@ namespace NTI\LogBundle\EventListener;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 use Symfony\Component\CssSelector\Parser\Token;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -36,7 +36,7 @@ class DoctrineEventSubscriber implements EventSubscriber
     public function postPersist(LifecycleEventArgs $args)
     {
         $this->logger = new Logger($this->container);
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
         if(is_string($entity)) {
             $entity = null;
         }
@@ -46,7 +46,7 @@ class DoctrineEventSubscriber implements EventSubscriber
     public function postUpdate(LifecycleEventArgs $args)
     {
         $this->logger = new Logger($this->container);
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
         if(is_string($entity)) {
             $entity = null;
         }
@@ -56,7 +56,7 @@ class DoctrineEventSubscriber implements EventSubscriber
     public function preRemove(LifecycleEventArgs $args)
     {
         $this->logger = new Logger($this->container);
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
         if(is_string($entity)) {
             $entity = null;
         }

--- a/Services/Logger.php
+++ b/Services/Logger.php
@@ -12,6 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use NTI\LogBundle\Entity\Log;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class Logger {
 
@@ -113,8 +115,9 @@ class Logger {
                 return;
             }
 
-            $reader = new AnnotationReader();
-            $excludeByAnnotation = $reader->getClassAnnotation(new \ReflectionClass($entity), 'NTI\\LogBundle\\Annotations\\ExcludeDoctrineLogging');
+            $reader = new AttributeLoader();            
+            $excludeByAnnotation = $reader->loadClassMetadata(new ClassMetadata($this->em->getClassMetadata(get_class($entity))->getName()));
+            
             if($excludeByAnnotation) {
                 return;
             }


### PR DESCRIPTION
> Issues resolved to migration Symfony 6.4 compabillibilty

1. fix issue with EventSuscriber and class LifecycleEventArgs this class now comes from use use Doctrine\Persistence\Event\LifecycleEventArgs on SF6.4
2. fix issue with Annotation reader intead use Attribute loader for SF6.4