### PR TITLE
fix issue with eventSuscriber on eventListener folder deprecation

### DIFF
--- a/EventListener/DoctrineEventSubscriber.php
+++ b/EventListener/DoctrineEventSubscriber.php
@@ -2,19 +2,13 @@
 
 namespace NTI\LogBundle\EventListener;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
-
-use Symfony\Component\CssSelector\Parser\Token;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
-use Symfony\Component\Security\Core\SecurityContext;
 use NTI\LogBundle\Entity\Log;
 use NTI\LogBundle\Services\Logger;
 
-class DoctrineEventSubscriber implements EventSubscriber
+class DoctrineEventListener
 {
     private $container;
     /** @var Logger $logger */

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,10 +1,10 @@
 services:
 
     nti.log.doctrine.listener:
-        class: NTI\LogBundle\EventListener\DoctrineEventSubscriber
+        class: NTI\LogBundle\EventListener\DoctrineEventListener
         arguments: ["@service_container"]
         tags:
-            - { name: doctrine.event_subscriber, connection: default }
+            - { name: doctrine.event_listener, event: kernel.exception, connection: default }
 
     nti.kernel.listener.kernelexception:
         class: NTI\LogBundle\EventListener\KernelExceptionListener


### PR DESCRIPTION
This error appear when you try to clean cache on Prod environment or run a Make refresh with Prod environment variable

{"message":"User Deprecated: Since symfony/doctrine-bridge 6.3: Registering \"NTI\\LogBundle\\EventListener\\DoctrineEventSubscriber\" as a Doctrine subscriber is deprecated. Register it as a listener instead, using e.g. the #[AsDoctrineListener] or #[AsDocumentListener] attribute.","context":{"exception":{"class":"ErrorException","message":"User Deprecated: Since symfony/doctrine-bridge 6.3: Registering \"NTI\\LogBundle\\EventListener\\DoctrineEventSubscriber\" as a Doctrine subscriber is deprecated. Register it as a listener instead, using e.g. the #[AsDoctrineListener] or #[AsDocumentListener] attribute.","code":0,"file":"/var/www/html/vendor/symfony/doctrine-bridge/ContainerAwareEventManager.php:211"}},"level":200,"level_name":"INFO","channel":"deprecation","datetime":"2024-04-30T14:12:07.804643+00:00","extra":{}}