### PR TITLE
fix issue to make relation between entity and database table

### DIFF
--- a/Entity/Log.php
+++ b/Entity/Log.php
@@ -6,7 +6,8 @@ use NTI\LogBundle\Annotations\ExcludeDoctrineLogging;
  * Log
  */
 #[ORM\Table(name: 'nti_log')]
- #[ORM\HasLifecycleCallbacks()]
+#[ORM\Entity(repositoryClass: 'NTI\LogBundle\Repository\LogRepository')]
+#[ORM\HasLifecycleCallbacks()]
 class Log
 {
     const LEVEL_NOTICE = "NOTICE";


### PR DESCRIPTION
On Symfony 6.4, the entity's Repository must be mapped by Doctrine.